### PR TITLE
Create View Catalog Page and Monsters Gallery

### DIFF
--- a/frontend/src/renderer/components/platform/pages/ViewCatalog.tsx
+++ b/frontend/src/renderer/components/platform/pages/ViewCatalog.tsx
@@ -1,0 +1,56 @@
+import * as React from 'react';
+import * as PropTypes from 'prop-types';
+import AppBar from '@material-ui/core/AppBar';
+import Tabs from '@material-ui/core/Tabs';
+import Tab from '@material-ui/core/Tab';
+import Typography from '@material-ui/core/Typography';
+
+import {Monster} from './view_catalog/Monster';
+
+import '../../../css/platform/pages/view_catalog.css';
+
+type AppProps = {}
+
+function TabContainer(props: TabContainer.propTypes) {
+  return (
+    <Typography component="div" style={{ padding: 8 * 3 }}>
+      {props.children}
+    </Typography>
+  );
+}
+
+TabContainer.propTypes = {
+  children: PropTypes.node.isRequired,
+};
+
+export const ViewCatalog: React.StatelessComponent<{}> = () => {
+	const [value, setValue] = React.useState(0);
+
+	function handleChange(event: AppProps, newValue: number) {
+		setValue(newValue);
+	}
+
+	return (
+		<div className="view-catalog-container">
+			<h1 className="page-title">View Catalog Items</h1>
+			<div className= "tab-root">
+			<AppBar position="static">
+				<Tabs value={value} onChange={handleChange}>
+					<Tab label="Monsters" />
+					<Tab label="Equipment" />
+					<Tab label="Locations" />
+					<Tab label="Buildings" />
+					<Tab label="Characters" />
+					<Tab label="Spells" />
+				</Tabs>
+			</AppBar>
+			{value === 0 && <TabContainer><Monster/></TabContainer>}
+			{value === 1 && <TabContainer>Equipment</TabContainer>}
+			{value === 2 && <TabContainer>Locations</TabContainer>}
+			{value === 3 && <TabContainer>Buildings</TabContainer>}
+			{value === 4 && <TabContainer>Characters</TabContainer>}
+			{value === 5 && <TabContainer>Spells</TabContainer>}
+			</div>
+		</div>
+	);
+}

--- a/frontend/src/renderer/components/platform/pages/view_catalog/Monster.tsx
+++ b/frontend/src/renderer/components/platform/pages/view_catalog/Monster.tsx
@@ -1,0 +1,49 @@
+import React from 'react';
+import Button from '@material-ui/core/Button';
+import Card from '@material-ui/core/Card';
+import CardActions from '@material-ui/core/CardActions';
+import CardContent from '@material-ui/core/CardContent';
+import CardMedia from '@material-ui/core/CardMedia';
+import Grid from '@material-ui/core/Grid';
+import Typography from '@material-ui/core/Typography';
+
+import '../../../../css/platform/pages/view-catalog/monster.css';
+
+// Dummy array of monsters
+const monsters = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12];
+
+export const Monster: React.StatelessComponent<{}> = () => {
+	return (
+		<div className= "layout card-grid">
+			<Grid container spacing={40}>
+				{monsters.map(monster => (
+					<Grid item key={monster} sm={6} md={4} lg={3}>
+						<Card className="card">
+						  <CardMedia
+							className="card-media"
+							image="data:image/svg+xml;charset=UTF-8,%3Csvg%20width%3D%22288%22%20height%3D%22225%22%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20viewBox%3D%220%200%20288%20225%22%20preserveAspectRatio%3D%22none%22%3E%3Cdefs%3E%3Cstyle%20type%3D%22text%2Fcss%22%3E%23holder_164edaf95ee%20text%20%7B%20fill%3A%23eceeef%3Bfont-weight%3Abold%3Bfont-family%3AArial%2C%20Helvetica%2C%20Open%20Sans%2C%20sans-serif%2C%20monospace%3Bfont-size%3A14pt%20%7D%20%3C%2Fstyle%3E%3C%2Fdefs%3E%3Cg%20id%3D%22holder_164edaf95ee%22%3E%3Crect%20width%3D%22288%22%20height%3D%22225%22%20fill%3D%22%2355595c%22%3E%3C%2Frect%3E%3Cg%3E%3Ctext%20x%3D%2296.32500076293945%22%20y%3D%22118.8%22%3EThumbnail%3C%2Ftext%3E%3C%2Fg%3E%3C%2Fg%3E%3C%2Fsvg%3E" // eslint-disable-line max-len
+							title="Image title"
+						  />
+						  <CardContent className="card-content">
+							<Typography gutterBottom variant="h5" component="h2">
+							  Monster {monster}
+							</Typography>
+							<Typography>
+							  Use this section to give a brief description of the monster.
+							</Typography>
+						  </CardContent>
+						  <CardActions>
+							<Button size="small" color="primary">
+							  View
+							</Button>
+							<Button size="small" color="primary">
+							  Edit
+							</Button>
+						  </CardActions>
+						</Card>
+					</Grid>
+				))}
+			</Grid>
+		</div>
+	);
+}

--- a/frontend/src/renderer/css/platform/pages/view-catalog/monster.css
+++ b/frontend/src/renderer/css/platform/pages/view-catalog/monster.css
@@ -1,0 +1,27 @@
+.view-catalog-container .app-bar {
+	position: relative;
+}
+
+.view-catalog-container .layout {
+	width: auto;
+	margin-left: 2%;
+	margin-right: 2%;
+}
+
+.view-catalog-container .card-grid {
+	padding: 8px 0;
+}
+
+.view-catalog-container .card {
+	height: 100%;
+	display: flex;
+	flex-direction: column;
+}
+
+.view-catalog-container .card-media {
+	padding-top: 56.25%; /* 16:9 */
+}
+
+.view-catalog-container .card-content {
+	flex-grow: 1;
+}

--- a/frontend/src/renderer/css/platform/pages/view_catalog.css
+++ b/frontend/src/renderer/css/platform/pages/view_catalog.css
@@ -1,0 +1,42 @@
+.view-catalog-container {
+	text-align: center;
+}
+.page-title {
+	background-color: #0074D9;
+	color: white;
+	padding: 5px 15px;
+	border-radius: 0.2em;
+	display: inline-block;
+}
+
+.view-catalog-container .tab-root {
+	flex-grow: 1;
+}
+
+.view-catalog-container .app-bar {
+	position: relative;
+}
+
+.view-catalog-container .layout {
+	width: auto;
+	margin-left: 2%;
+	margin-right: 2%;
+}
+
+.view-catalog-container .card-grid {
+	padding: 8px 0;
+}
+
+.view-catalog-container .card {
+	height: 100%;
+	display: flex;
+	flex-direction: column;
+}
+
+.view-catalog-container .card-media {
+	padding-top: 56.25%; /* 16:9 */
+}
+
+.view-catalog-container .card-content {
+	flex-grow: 1;
+}

--- a/frontend/src/renderer/css/platform/pages/view_catalog.css
+++ b/frontend/src/renderer/css/platform/pages/view_catalog.css
@@ -2,10 +2,7 @@
 	text-align: center;
 }
 .page-title {
-	background-color: #0074D9;
-	color: white;
 	padding: 5px 15px;
-	border-radius: 0.2em;
 	display: inline-block;
 }
 

--- a/frontend/test/components/__snapshots__/view_catalog.test.tsx.snap
+++ b/frontend/test/components/__snapshots__/view_catalog.test.tsx.snap
@@ -1,0 +1,47 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Test the View Catalog Page renders correctly when the page is loaded 1`] = `
+<div
+  className="view-catalog-container"
+>
+  <h1
+    className="page-title"
+  >
+    View Catalog Items
+  </h1>
+  <div
+    className="tab-root"
+  >
+    <WithStyles(AppBar)
+      position="static"
+    >
+      <WithStyles(Tabs)
+        onChange={[Function]}
+        value={0}
+      >
+        <WithStyles(Tab)
+          label="Monsters"
+        />
+        <WithStyles(Tab)
+          label="Equipment"
+        />
+        <WithStyles(Tab)
+          label="Locations"
+        />
+        <WithStyles(Tab)
+          label="Buildings"
+        />
+        <WithStyles(Tab)
+          label="Characters"
+        />
+        <WithStyles(Tab)
+          label="Spells"
+        />
+      </WithStyles(Tabs)>
+    </WithStyles(AppBar)>
+    <TabContainer>
+      <Component />
+    </TabContainer>
+  </div>
+</div>
+`;

--- a/frontend/test/components/view_catalog.test.tsx
+++ b/frontend/test/components/view_catalog.test.tsx
@@ -1,0 +1,16 @@
+import * as React from 'react';
+import {shallow} from 'enzyme';
+import {ViewCatalog} from '../../src/renderer/components/platform/pages/ViewCatalog';
+
+
+describe('Test the View Catalog Page', () => {
+	const viewCatalogInstance = shallow(<ViewCatalog/>);
+
+	it('renders without crashing', () => {
+		expect(viewCatalogInstance).toBeDefined();
+	});
+
+	it('renders correctly when the page is loaded', () => {
+		expect(viewCatalogInstance).toMatchSnapshot();
+	});
+});


### PR DESCRIPTION
This commit is part of #30

Apart from the Monsters Gallery, the View Catalog page is also created and will be used to view other items (e.g. buildings, spells, etc.) as well.

The View Catalog page will be displayed in the right half of the interactive main page (see https://github.com/UIOWA5830SP19/SPP500/blob/master/doc/lofi/main_page.png) When the user is clicked on the 'Monsters' tab, the Monster gallery is shown. Since the backend is not yet ready, the monsters act as dummy values.

For now, this page is rendered and tested by itself. When the routing is implemented and main page is implemented, then the user will be able to access this page through the menu. This is the rendered version of the new page:

![image](https://user-images.githubusercontent.com/14010967/52905893-aae77980-3206-11e9-89ee-693093a29793.png)
