### PR TITLE
David mock monster

### DIFF
--- a/backend/entity/Monster.ts
+++ b/backend/entity/Monster.ts
@@ -3,67 +3,7 @@ import { MonsterAbilityScore } from "./MonsterAbilityScore";
 import { MonsterSkill } from "./MonsterSkill";
 import { MonsterSavingThrow } from "./MonsterSavingThrow";
 import { Encounter } from "./Encounter";
-
-export enum Size {
-    Tiny = "Tiny",
-    Small = "Small",
-    Medium = "Medium",
-    Large = "Large",
-    Huge = "Huge",
-    Gargantuan = "Gargantuan"
-}
-
-export enum MonsterType {
-    Beast = "Beast",
-    Dragon = "Dragon",
-    Monstrosity = "Monstrosity",
-    Humanoid = "Humanoid",
-    Fiend = "Fiend",
-    Undead = "Undead",
-    Giant = "Giant",
-    Elemental = "Elemental",
-    SwarmOfTinyBeasts = "SwarmOfTinyBeasts",
-    Construct = "Construct",
-    Celestial = "Celestial",
-    Aberration = "Aberration",
-    Fey = "Fey",
-    Plant = "Plant",
-    Ooze = "Ooze"
-}
-
-export enum MonsterRace {
-    AnyRace = "AnyRace",
-    Devil = "Devil",
-    Demon = "Demon",
-    Human = "Human",
-    Shapechanger = "Shapechanger",
-    Goblinoid = "Goblinoid",
-    Titan = "Titan",
-    Gnoll = "Gnoll",
-    Gnome = "Gnome",
-    Dwarf = "Dwarf",
-    Elf = "Elf",
-    Orc = "Orc",
-    Kobold = "Kobold",
-    Lizardfolk = "Lizardfolk",
-    Merfolk = "Merfolk",
-    Sahuagin = "Sahuagin",
-    Grimlock = "Grimlock"
-}
-
-export enum Alignment {
-    Unaligned = "Unaligned",
-    AnyAlignment = "AnyAlignment",
-    LawfulDood = "LawfulDood",
-    LawfulNeutral = "LawfulNeutral",
-    LawfulEvil = "LawfulEvil",
-    NeutralGood = "NeutralGood",
-    Neutral = "Neutral",
-    NeutralEvil = "NeutralEvil",
-    ChaoticGood = "ChaoticGood",
-    ChaoticNeutral = "ChaoticNeutral",
-    ChaoticEvil = "ChaoticEvil"
-}
+import { Size, MonsterType, MonsterRace, Alignment } from "./MonsterEnums";
 
 @Entity()
 export class Monster extends BaseEntity {

--- a/backend/entity/MonsterEnums.ts
+++ b/backend/entity/MonsterEnums.ts
@@ -1,0 +1,60 @@
+export enum Size {
+    Tiny = "Tiny",
+    Small = "Small",
+    Medium = "Medium",
+    Large = "Large",
+    Huge = "Huge",
+    Gargantuan = "Gargantuan"
+}
+
+export enum MonsterType {
+    Beast = "Beast",
+    Dragon = "Dragon",
+    Monstrosity = "Monstrosity",
+    Humanoid = "Humanoid",
+    Fiend = "Fiend",
+    Undead = "Undead",
+    Giant = "Giant",
+    Elemental = "Elemental",
+    SwarmOfTinyBeasts = "SwarmOfTinyBeasts",
+    Construct = "Construct",
+    Celestial = "Celestial",
+    Aberration = "Aberration",
+    Fey = "Fey",
+    Plant = "Plant",
+    Ooze = "Ooze"
+}
+
+export enum MonsterRace {
+    AnyRace = "AnyRace",
+    Devil = "Devil",
+    Demon = "Demon",
+    Human = "Human",
+    Shapechanger = "Shapechanger",
+    Goblinoid = "Goblinoid",
+    Titan = "Titan",
+    Gnoll = "Gnoll",
+    Gnome = "Gnome",
+    Dwarf = "Dwarf",
+    Elf = "Elf",
+    Orc = "Orc",
+    Kobold = "Kobold",
+    Lizardfolk = "Lizardfolk",
+    Merfolk = "Merfolk",
+    Sahuagin = "Sahuagin",
+    Grimlock = "Grimlock"
+}
+
+export enum Alignment {
+    Unaligned = "Unaligned",
+    AnyAlignment = "AnyAlignment",
+    LawfulDood = "LawfulDood",
+    LawfulNeutral = "LawfulNeutral",
+    LawfulEvil = "LawfulEvil",
+    NeutralGood = "NeutralGood",
+    Neutral = "Neutral",
+    NeutralEvil = "NeutralEvil",
+    ChaoticGood = "ChaoticGood",
+    ChaoticNeutral = "ChaoticNeutral",
+    ChaoticEvil = "ChaoticEvil"
+}

--- a/backend/entity/__mocks__/Monster.ts
+++ b/backend/entity/__mocks__/Monster.ts
@@ -19,12 +19,12 @@ export class Monster {
 	DamageResistances: string;
 	DamageImmunities: string;
 	ConditionImmunities: string;
-	ChallengeRating: number;
-	AbilityScores: MonsterAbilityScore[];
+    ChallengeRating: number;
+	AbilityScores: MonsterAbilityScore;
 	Skills: MonsterSkill[];
-	SavingThrows: MonsterSavingThrow[];
+	SavingThrows: MonsterSavingThrow;
 
-	[key: string]: string|number|MonsterAbilityScore[]|MonsterSkill[]|MonsterSavingThrow[]|(()=>void);
+	[key: string]: string|number|MonsterAbilityScore|MonsterSkill[]|MonsterSavingThrow|(()=>void);
 
 	static TableRows: Monster[] = [];
 

--- a/backend/entity/__mocks__/Monster.ts
+++ b/backend/entity/__mocks__/Monster.ts
@@ -1,7 +1,7 @@
 import { MonsterAbilityScore } from "./MonsterAbilityScore";
 import { MonsterSkill } from "./MonsterSkill";
 import { MonsterSavingThrow } from "./MonsterSavingThrow";
-import { Size, MonsterType, MonsterRace, Alignment } from "../Monster"
+import { Size, MonsterType, MonsterRace, Alignment } from "../MonsterEnums";
 
 export class Monster {
 	Name: string;

--- a/backend/entity/__mocks__/Monster.ts
+++ b/backend/entity/__mocks__/Monster.ts
@@ -1,68 +1,7 @@
 import { MonsterAbilityScore } from "./MonsterAbilityScore";
 import { MonsterSkill } from "./MonsterSkill";
 import { MonsterSavingThrow } from "./MonsterSavingThrow";
-
-export enum Size {
-	Tiny = "Tiny",
-	Small = "Small",
-	Medium = "Medium",
-	Large = "Large",
-	Huge = "Huge",
-	Gargantuan = "Gargantuan"
-}
-	
-
-export enum MonsterType {
-	Beast = "Beast",
-	Dragon = "Dragon",
-	Monstrosity = "Monstrosity",
-	Humanoid = "Humanoid",
-	Fiend = "Fiend",
-	Undead = "Undead",
-	Giant = "Giant",
-	Elemental = "Elemental",
-	SwarmOfTinyBeasts = "SwarmOfTinyBeasts",
-	Construct = "Construct",
-	Celestial = "Celestial",
-	Aberration = "Aberration",
-	Fey = "Fey",
-	Plant = "Plant",
-	Ooze = "Ooze"
-}
-
-export enum MonsterRace {
-	AnyRace = "AnyRace",
-	Devil = "Devil",
-	Demon = "Demon",
-	Human = "Human",
-	Shapechanger = "Shapechanger",
-	Goblinoid = "Goblinoid",
-	Titan = "Titan",
-	Gnoll = "Gnoll",
-	Gnome = "Gnome",
-	Dwarf = "Dwarf",
-	Elf = "Elf",
-	Orc = "Orc",
-	Kobold = "Kobold",
-	Lizardfolk = "Lizardfolk",
-	Merfolk = "Merfolk",
-	Sahuagin = "Sahuagin",
-	Grimlock = "Grimlock"
-}
-
-export enum Alignment {
-	Unaligned = "Unaligned",
-	AnyAlignment = "AnyAlignment",
-	LawfulDood = "LawfulDood",
-	LawfulNeutral = "LawfulNeutral",
-	LawfulEvil = "LawfulEvil",
-	NeutralGood = "NeutralGood",
-	Neutral = "Neutral",
-	NeutralEvil = "NeutralEvil",
-	ChaoticGood = "ChaoticGood",
-	ChaoticNeutral = "ChaoticNeutral",
-	ChaoticEvil = "ChaoticEvil"
-}
+import { Size, MonsterType, MonsterRace, Alignment } from "../Monster"
 
 export class Monster {
 	Name: string;

--- a/backend/monster.test.ts
+++ b/backend/monster.test.ts
@@ -1,4 +1,4 @@
-import {MonsterClass} from "./monster";
+import {MonsterFactory} from "./monster";
 
 jest.mock("./entity/AbilityScore");
 jest.mock("./entity/Monster");
@@ -8,7 +8,7 @@ jest.mock("./entity/MonsterSkill");
 jest.mock("./entity/Skill");
 
 describe('monster creation tests', async () => {
-	var monster = new MonsterClass();
+	var monster = new MonsterFactory();
 
 	test('when proper data is given', async () => {
 		const response = await monster.Create({

--- a/backend/monster.ts
+++ b/backend/monster.ts
@@ -155,10 +155,10 @@ export class MonsterFactory {
 
 		// MonsterAbilityScore
 		var abilityScore = data.AbilityScores
+		var monsterAbilityScore = new MonsterAbilityScore();
+		monsterAbilityScore.Monster = monster;
+		monster.AbilityScores = monsterAbilityScore;
 		if (abilityScore) {
-			var monsterAbilityScore = new MonsterAbilityScore();
-			monsterAbilityScore.Monster = monster;
-			monster.AbilityScores = monsterAbilityScore;
 
 			if (abilityScore.Strength && typeof abilityScore.Strength !== 'number') {
 				messages.push("Strength value for AbilityScores is not valid: " + abilityScore.Strength)
@@ -199,10 +199,10 @@ export class MonsterFactory {
 
 		// MonsterSavingThrow
 		var savingThrow = data.SavingThrows
+		var monsterSavingThrow = new MonsterSavingThrow();
+		monsterSavingThrow.Monster = monster;
+		monster.SavingThrows = monsterSavingThrow;
 		if (savingThrow) {
-			var monsterSavingThrow = new MonsterSavingThrow();
-			monsterSavingThrow.Monster = monster;
-			monster.SavingThrows = monsterSavingThrow;
 
 			if (savingThrow.Strength && typeof savingThrow.Strength !== 'number') {
 				messages.push("Strength value for SavingThrows is not valid: " + savingThrow.Strength)

--- a/backend/monster.ts
+++ b/backend/monster.ts
@@ -157,6 +157,7 @@ export class MonsterFactory {
 		if (abilityScore) {
 			var monsterAbilityScore = new MonsterAbilityScore();
 			monsterAbilityScore.Monster = monster;
+			monster.AbilityScores = monsterAbilityScore;
 
 			if (abilityScore.Strength && typeof abilityScore.Strength !== 'number') {
 				messages.push("Strength value for AbilityScores is not valid: " + abilityScore.Strength)
@@ -193,7 +194,6 @@ export class MonsterFactory {
 			} else {
 				monsterAbilityScore.Charisma = abilityScore.Charisma;
 			}
-
 		}
 
 		// MonsterSavingThrow
@@ -201,6 +201,7 @@ export class MonsterFactory {
 		if (savingThrow) {
 			var monsterSavingThrow = new MonsterSavingThrow();
 			monsterSavingThrow.Monster = monster;
+			monster.SavingThrows = monsterSavingThrow;
 
 			if (savingThrow.Strength && typeof savingThrow.Strength !== 'number') {
 				messages.push("Strength value for SavingThrows is not valid: " + savingThrow.Strength)
@@ -264,16 +265,15 @@ export class MonsterFactory {
 			}
 		}
 
-
-		monster.AbilityScores = abilityScore;
-		monster.SavingThrows = savingThrow;
 		monster.Skills = skillsArray;
 		
 
 		// save to db
 		if (messages.length == 0) {
+			await monster.AbilityScores.save();
+			await monster.SavingThrows.save();
 			await monster.save();
-			for (let skill of skillsArray) await skill.save();
+			for (let skill of monster.Skills ) await skill.save();
 
 			return {
 				"status": 201,

--- a/backend/monster.ts
+++ b/backend/monster.ts
@@ -78,32 +78,25 @@ export class MonsterFactory {
 			monster.Senses = data.Senses;
 		}
 
-
 		if (data.Languages) {
 			monster.Languages = data.Languages;
 		}
-		
 
 		if (data.DamageVulnerabilities) {
 			monster.DamageVulnerabilities = data.DamageVulnerabilities;
 		}
-		
 
 		if (data.DamageResistances) {
 			monster.DamageResistances = data.DamageResistances;
 		}
-		
 
 		if (data.DamageImmunities) {
 			monster.DamageImmunities = data.DamageImmunities;
 		}
-		
 
 		if (data.ConditionImmunities) {
 			monster.ConditionImmunities = data.ConditionImmunities;
 		}
-		
-
 
 		// check if enum fields are properly provided
 		// if not raise an error

--- a/backend/monster.ts
+++ b/backend/monster.ts
@@ -1,4 +1,5 @@
-import {Size, MonsterType, MonsterRace, Alignment, Monster} from "./entity/Monster";
+import {Monster} from "./entity/Monster";
+import { Size, MonsterType, MonsterRace, Alignment } from "./entity/MonsterEnums";
 import {Skill} from "./entity/Skill"
 import {MonsterAbilityScore} from "./entity/MonsterAbilityScore";
 import {MonsterSavingThrow} from "./entity/MonsterSavingThrow";

--- a/backend/monster.ts
+++ b/backend/monster.ts
@@ -58,7 +58,7 @@ Sample curl request,
 }' \
  http://localhost:3000/monster/create
  */
-export class MonsterClass {
+export class MonsterFactory {
 	public async Create(request: {payload: any}) {
 		var data = request.payload;
 		const monster = new Monster();

--- a/backend/monster.ts
+++ b/backend/monster.ts
@@ -67,49 +67,43 @@ export class MonsterFactory {
 
 		// check if fields with no defaults are provided
 		// if not raise an error
-		// name, senses, languages
+		// only name is required
 		if (!data.Name) {
 			messages.push("Name must be provided.");
 		}
 
 		monster.Name = data.Name;
 
-		if (!data.Senses) {
-			messages.push("Senses must be provided.");
+		if (data.Senses) {
+			monster.Senses = data.Senses;
 		}
 
-		monster.Senses = data.Senses;
 
-		if (!data.Languages) {
-			messages.push("Languages must be provided.");
+		if (data.Languages) {
+			monster.Languages = data.Languages;
 		}
 		
-		monster.Languages = data.Languages;
 
-		if (!data.DamageVulnerabilities) {
-			messages.push("DamageVulnerabilities must be provided.");
+		if (data.DamageVulnerabilities) {
+			monster.DamageVulnerabilities = data.DamageVulnerabilities;
 		}
 		
-		monster.DamageVulnerabilities = data.DamageVulnerabilities;
 
-		if (!data.DamageResistances) {
-			messages.push("DamageResistances must be provided.");
+		if (data.DamageResistances) {
+			monster.DamageResistances = data.DamageResistances;
 		}
 		
-		monster.DamageResistances = data.DamageResistances;
 
-		if (!data.DamageImmunities) {
-			messages.push("DamageImmunities must be provided.");
+		if (data.DamageImmunities) {
+			monster.DamageImmunities = data.DamageImmunities;
 		}
 		
-		monster.DamageImmunities = data.DamageImmunities;
 
-		if (!data.ConditionImmunities) {
-			messages.push("ConditionImmunities must be provided.");
+		if (data.ConditionImmunities) {
+			monster.ConditionImmunities = data.ConditionImmunities;
 		}
 		
-		monster.ConditionImmunities = data.ConditionImmunities;
-		
+
 
 		// check if enum fields are properly provided
 		// if not raise an error

--- a/backend/ormconfig.json
+++ b/backend/ormconfig.json
@@ -17,7 +17,8 @@
         "cli": {
             "entitiesDir": "./entity",
             "migrationsDir": "./migrations"
-        }
+        },
+        "logging": "all"
     },
     {
         "name": "seed",

--- a/backend/server.ts
+++ b/backend/server.ts
@@ -7,7 +7,7 @@ import * as JWTHapi from "hapi-auth-jwt2";
 import {User} from "./entity/User";
 import {Registration} from "./registration";
 import {Login} from "./login";
-import {MonsterClass} from "./monster";
+import {MonsterFactory} from "./monster";
 
 export const Server = new Hapi.Server({
 	port: 3000,
@@ -50,7 +50,7 @@ export const initServer = async () => {
 		path: '/monster/create', 
 		options: { auth: 'jwt' },
 		handler: function (request) {
-			var monster = new MonsterClass();
+			var monster = new MonsterFactory();
 			return monster.Create(request);
 		}
 	},


### PR DESCRIPTION
We should use the types that are defined by the actual monster class. There is no reason to mock an Enum type its just duplicate code that will eventually not be equal.

Remove the array specification for ability scores and saving throws, just a typo I assume.

I think it is more natural to call it a factory rather than MonsterClass.

Default values for Damage, Condition, and Language are all null, and most creatures don't have these features. It would be a burden to require them.

Saving the monster was not working for me so I made separated it into pieces. 