### PR TITLE
Add route to verify user tokens.

### DIFF
--- a/backend/server.ts
+++ b/backend/server.ts
@@ -66,6 +66,17 @@ export const initServer = async () => {
 	},
 	{
 		method: 'GET',
+		path: '/verify', 
+		options: { auth: 'jwt' },
+		handler: function (request) {
+			return {
+				"status": 200,
+				"message": "That is a valid token."
+			};
+		}
+	},
+	{
+		method: 'GET',
 		path: '/test',
 		options: { auth: false },
 		handler: function (request) {


### PR DESCRIPTION
Add a simple way to check if a token is valid. Maybe this isn't the best way to do it. Because incorrect tokens just get access denied which might confuse the standard user. They might expect to reach the url which would then return a boolean value or something similar instead of an outright deny.