### PR TITLE
remove array initializers, fixes problem seeding the database

### DIFF
--- a/backend/entity/Monster.ts
+++ b/backend/entity/Monster.ts
@@ -163,16 +163,16 @@ export class Monster extends BaseEntity implements IMonsterData {
     AbilityScores: MonsterAbilityScore;
 
     @OneToMany(() => MonsterSkill, monsterSkill => monsterSkill.Monster)
-    Skills: MonsterSkill[] = [];
+    Skills: MonsterSkill[];
 
     @OneToOne(() => MonsterSavingThrow, monsterSavingThrow => monsterSavingThrow.Monster)
     @JoinColumn()
     SavingThrows: MonsterSavingThrow;
 
     @OneToMany(() => Action, action => action.Monster)
-    Actions: Action[] = [];
+    Actions: Action[];
 
     @ManyToMany(() => Encounter, encounter => encounter.Monsters)
-    Encounters: Encounter[] = [];
+    Encounters: Encounter[];
 
 }


### PR DESCRIPTION
HOTFIX seeding the database.

To test run "docker-compose up --build" without this change you should get errors when the backend server tries to seed the database.